### PR TITLE
Escape spaces in path

### DIFF
--- a/ftplugin/plantuml.vim
+++ b/ftplugin/plantuml.vim
@@ -13,7 +13,9 @@ let g:loaded_plantuml_plugin = 1
 if !exists("g:plantuml_executable_script")
 	let g:plantuml_executable_script="plantuml"
 endif
-let s:makecommand=g:plantuml_executable_script." %"
+let s:path=expand("%")
+let s:path=fnameescape(s:path)
+let s:makecommand=g:plantuml_executable_script." ".s:path
 
 " define a sensible makeprg for plantuml files
 autocmd Filetype plantuml let &l:makeprg=s:makecommand


### PR DESCRIPTION
The command :make is not working when you have spaces in your path. The code adds escapes spaces with a "\" sign.  

You have also add this line into your .vimrc:

```
let g:plantuml_executable_script='java -jar /path/to/plantuml.jar -v'
```

The suggested script which has to be placed into a plantuml file doesn't worked for me.
