### PR TITLE
`isnot#` operator cannot be used

### DIFF
--- a/syntax/plantuml.vim
+++ b/syntax/plantuml.vim
@@ -18,7 +18,6 @@ let b:current_syntax = "plantuml"
 syntax sync minlines=100
 
 setlocal isident+=@
-setlocal isident+=#
 
 syntax match plantumlPreProc /\%(^@startuml\|^@enduml\)\|!\%(include\|ifdef\|define\|endif\)\s*.*/ contains=plantumlDir
 syntax region plantumlDir start=/\s\+/ms=s+1 end=/$/ contained


### PR DESCRIPTION
The `setlocal isident+=#` statement makes `isnot#` operator unusable. This code below is the procedure for reproducing.

```vim
vim -u NONE
:echo {} isnot# {}
1
:setlocal isident+=#
:echo {} isnot# {}
E121: Undefined variable: isnot#
E15: Invalid expression: isnot# {}
```

So I cannot use `plantuml-syntax` with other plugins using `isnot#` (such as [vim-rails][]). Maybe this is a vim bug? or methods of vim? I don't know.

[vim-rails]: https://github.com/tpope/vim-rails/blob/master/autoload/rails.vim#L4494

I'm not good for PlantUML, but please remove this statement if not making any problems.