### PR TITLE
Corrected filetype detection

### DIFF
--- a/ftdetect/plantuml.vim
+++ b/ftdetect/plantuml.vim
@@ -8,5 +8,5 @@ if did_filetype()
 	  finish
 endif
 
-autocmd BufRead,BufNewFile * :if getline(1) =~ '^.*startuml.*$'|  setfiletype plantuml | endif
-autocmd BufRead,BufNewFile *.pu,*.uml,*.plantuml set filetype=plantuml
+autocmd BufRead,BufNewFile * :if getline(1) =~ '^.*startuml.*$'| setfiletype plantuml | set filetype=plantuml | endif
+autocmd BufRead,BufNewFile *.pu,*.uml,*.plantuml setfiletype plantuml | set filetype=plantuml


### PR DESCRIPTION
The current filetype detection is just a little wonky. This can be noticed if you comment out either line in the ftdetect/plantuml.vim file, open up a file that should be detected by the remaining line, and checking the makeprg value for the correct script without making any edits. This commit fixed the issue on my system. I'm pretty new to vim scripting, so there may be a better way to accomplish the same task.