### PR TITLE
Support endwise

### DIFF
--- a/ftplugin/plantuml.vim
+++ b/ftplugin/plantuml.vim
@@ -16,3 +16,8 @@ endif
 let &l:makeprg=g:plantuml_executable_script . " " .  fnameescape(expand("%"))
 
 setlocal comments=s1:/',mb:',ex:'/,:' commentstring=/'%s'/ formatoptions-=t formatoptions+=croql
+
+let b:endwise_addition = '\=index(["note","legend"], submatch(0))!=-1 ? "end " . submatch(0) : "end"'
+let b:endwise_words = 'loop,group,alt,note,legend'
+let b:endwise_pattern = '^\s*\zs\<\(loop\|group\|alt\|note\ze[^:]*$\|legend\)\>.*$'
+let b:endwise_syngroups = 'plantumlKeyword'

--- a/ftplugin/plantuml.vim
+++ b/ftplugin/plantuml.vim
@@ -4,15 +4,15 @@
 " Last Change:  19-Jun-2012
 " Version:      0.1
 
-if exists("g:loaded_plantuml_plugin")
+if exists("b:loaded_plantuml_plugin")
     finish
 endif
-let g:loaded_plantuml_plugin = 1
+let b:loaded_plantuml_plugin = 1
 
 if !exists("g:plantuml_executable_script")
 	let g:plantuml_executable_script="plantuml"
 endif
 
-autocmd Filetype plantuml let &l:makeprg=g:plantuml_executable_script . " " .  fnameescape(expand("%"))
+let &l:makeprg=g:plantuml_executable_script . " " .  fnameescape(expand("%"))
 
 setlocal comments=s1:/',mb:',ex:'/,:' commentstring=/'%s'/ formatoptions-=t formatoptions+=croql


### PR DESCRIPTION
I have 2 commits:

1. Fix the way the ftplugin is loaded. This way the file is sourced once for each plantuml buffer. It's simpler and more standard.

2. I have added support for the endwise plugin --> https://github.com/tpope/vim-endwise.

This plugin magically completes certain things for you. For example:

```
note left  <<< if you type this and hit enter
end note <<< this will be magically inserted and the cursor placed between the 2 lines
```

However, I see the current syntax file doesn't match some of the plantuml keywords e.g. `loop`. So endwise wont work for them.

I notice that @hokorobi has fixed this in his fork. @hokorobi - any plans for a pull request?