### PR TITLE
Support for partition {}

### DIFF
--- a/syntax/plantuml.vim
+++ b/syntax/plantuml.vim
@@ -39,8 +39,9 @@ syntax region plantumlLabel start=/\[/ms=s+1 end=/\]/me=s-1 contained contains=p
 syntax match plantumlText /\%([0-9A-Za-zÀ-ÿ]\|\s\|[\.,;_-]\)\+/ contained
 
 " Class
-syntax region plantumlClass matchgroup=plantumlTypeKeyword start=/\s*class [^{]\+{/ end=/\s*}/ contains=plantumlKeyword,
-\                                                                                                       @plantumlClassOp
+syntax region plantumlClassString matchgroup=plantumlClass start=/\s*class\ze [^{]\+{/ end=/\s*\ze}/ contains=plantumlKeyword,
+\                                                                                                             @plantumlClassOp
+syntax match plantumlClass /\s*class\ze [^{]\+$/
 
 syntax match plantumlClassPublic      /+\w\+/ contained
 syntax match plantumlClassPrivate     /-\w\+/ contained
@@ -151,6 +152,7 @@ highlight default link plantumlDirectedOrVerticalArrowLR Special
 highlight default link plantumlDirectedOrVerticalArrowRL Special
 highlight default link plantumlLabel Special
 highlight default link plantumlText Label
+highlight default link plantumlClass Type
 highlight default link plantumlClassPublic Structure
 highlight default link plantumlClassPrivate Macro
 highlight default link plantumlClassProtected Statement

--- a/syntax/plantuml.vim
+++ b/syntax/plantuml.vim
@@ -23,7 +23,7 @@ syntax sync minlines=100
 syntax match plantumlPreProc /\%(^@startuml\|^@enduml\)\|!\%(include\|define\|undev\|ifdef\|endif\|ifndef\)\s*.*/ contains=plantumlDir
 syntax region plantumlDir start=/\s\+/ms=s+1 end=/$/ contained
 
-syntax keyword plantumlTypeKeyword actor participant usecase class interface abstract enum component state object artifact folder rect node frame cloud database storage agent boundary control entity card
+syntax keyword plantumlTypeKeyword actor participant usecase interface abstract enum component state object artifact folder rect node frame cloud database storage agent boundary control entity card
 syntax keyword plantumlKeyword as also autonumber caption title newpage box alt opt loop par break critical note rnote hnote legend group left right of on link over end activate deactivate destroy create footbox hide show skinparam skin top bottom
 syntax keyword plantumlKeyword package namespace page up down if else elseif endif partition footer header center rotate ref return is repeat start stop while endwhile fork again kill
 syntax keyword plantumlKeyword then detach
@@ -39,9 +39,8 @@ syntax region plantumlLabel start=/\[/ms=s+1 end=/\]/me=s-1 contained contains=p
 syntax match plantumlText /\%([0-9A-Za-zÀ-ÿ]\|\s\|[\.,;_-]\)\+/ contained
 
 " Class
-syntax region plantumlClass start=/{/ end=/\s*}/ contains=plantumlClassArrows,
-\                                                         plantumlKeyword,
-\                                                         @plantumlClassOp
+syntax region plantumlClass matchgroup=plantumlTypeKeyword start=/\s*class [^{]\+{/ end=/\s*}/ contains=plantumlKeywor,
+\                                                                                                       @plantumlClassOp
 
 syntax match plantumlClassPublic      /+\w\+/ contained
 syntax match plantumlClassPrivate     /-\w\+/ contained

--- a/syntax/plantuml.vim
+++ b/syntax/plantuml.vim
@@ -39,7 +39,7 @@ syntax region plantumlLabel start=/\[/ms=s+1 end=/\]/me=s-1 contained contains=p
 syntax match plantumlText /\%([0-9A-Za-zÀ-ÿ]\|\s\|[\.,;_-]\)\+/ contained
 
 " Class
-syntax region plantumlClass matchgroup=plantumlTypeKeyword start=/\s*class [^{]\+{/ end=/\s*}/ contains=plantumlKeywor,
+syntax region plantumlClass matchgroup=plantumlTypeKeyword start=/\s*class [^{]\+{/ end=/\s*}/ contains=plantumlKeyword,
 \                                                                                                       @plantumlClassOp
 
 syntax match plantumlClassPublic      /+\w\+/ contained


### PR DESCRIPTION
By a definition of plantumlClass, partition <partition name> {} it wasn't colored, so it was changed to avoided it.
But class <class name>  {} everything is colored, so it may not be the best definition.

There is no definitions, so plantumlClassArrows deleted.