### PR TITLE
Add indent pattern

### DIFF
--- a/indent/plantuml.vim
+++ b/indent/plantuml.vim
@@ -12,13 +12,13 @@ if exists("*GetPlantUMLIndent")
 endif
 
 let s:incIndent =
-      \ '^\s*\(loop\|alt\|opt\|group\|critical\|else\|legend\|box\)\>\|' .
-      \ '^\s*\([hr]\?note\|ref\)\>[^:]*$\|' .
+      \ '^\s*\%(loop\|alt\|opt\|group\|critical\|else\|legend\|box\|if\|while\)\>\|' .
+      \ '^\s*\%([hr]\?note\|ref\)\>[^:]*$\|' .
       \ '^\s*title\s*$\|' .
       \ '^\s*skinparam\>.*{\s*$\|' .
-      \ '^\s*state\>.*{'
+      \ '^\s*\%(state\|class\|partition\|rectangle\)\>.*{'
 
-let s:decIndent = '^\s*\(end\|else\|}\)'
+let s:decIndent = '^\s*\%(end\|else\|}\)'
 
 function! GetPlantUMLIndent(...) abort
   "for current line, use arg if given or v:lnum otherwise

--- a/indent/plantuml.vim
+++ b/indent/plantuml.vim
@@ -12,43 +12,43 @@ if exists("*GetPlantUMLIndent")
 endif
 
 let s:incIndent =
-            \ '^\s*\(loop\|alt\|opt\|group\|critical\|else\|legend\|box\)\>\|' .
-            \ '^\s*\([hr]\?note\|ref\)\>[^:]*$\|' .
-            \ '^\s*title\s*$\|' .
-            \ '^\s*skinparam\>.*{\s*$\|' .
-            \ '^\s*state\>.*{'
+      \ '^\s*\(loop\|alt\|opt\|group\|critical\|else\|legend\|box\)\>\|' .
+      \ '^\s*\([hr]\?note\|ref\)\>[^:]*$\|' .
+      \ '^\s*title\s*$\|' .
+      \ '^\s*skinparam\>.*{\s*$\|' .
+      \ '^\s*state\>.*{'
 
 let s:decIndent = '^\s*\(end\|else\|}\)'
 
 function! GetPlantUMLIndent(...) abort
-    "for current line, use arg if given or v:lnum otherwise
-    let clnum = a:0 ? a:1 : v:lnum
+  "for current line, use arg if given or v:lnum otherwise
+  let clnum = a:0 ? a:1 : v:lnum
 
-    if !s:insidePlantUMLTags(clnum)
-        return indent(clnum)
+  if !s:insidePlantUMLTags(clnum)
+    return indent(clnum)
+  endif
+
+  let pnum = prevnonblank(clnum-1)
+  let pindent = indent(pnum) 
+  let pline = getline(pnum)
+  let cline = getline(clnum)
+
+  if cline =~ s:decIndent
+    if pline =~ s:incIndent
+      return pindent
+    else
+      return pindent - shiftwidth()
     endif
 
-    let pnum = prevnonblank(clnum-1)
-    let pindent = indent(pnum) 
-    let pline = getline(pnum)
-    let cline = getline(clnum)
+  elseif pline =~ s:incIndent
+    return pindent + shiftwidth()
+  endif
 
-    if cline =~ s:decIndent
-        if pline =~ s:incIndent
-            return pindent
-        else
-            return pindent - shiftwidth()
-        endif
-
-    elseif pline =~ s:incIndent
-        return pindent + shiftwidth()
-    endif
-
-    return pindent
+  return pindent
 
 endfunction
 
 function! s:insidePlantUMLTags(lnum) abort
-    call cursor(a:lnum, 1)
-    return search('@startuml', 'Wbn') && search('@enduml', 'Wn')
+  call cursor(a:lnum, 1)
+  return search('@startuml', 'Wbn') && search('@enduml', 'Wn')
 endfunction

--- a/indent/plantuml.vim
+++ b/indent/plantuml.vim
@@ -29,7 +29,7 @@ function! GetPlantUMLIndent(...) abort
   endif
 
   let pnum = prevnonblank(clnum-1)
-  let pindent = indent(pnum) 
+  let pindent = indent(pnum)
   let pline = getline(pnum)
   let cline = getline(clnum)
 

--- a/indent/plantuml.vim
+++ b/indent/plantuml.vim
@@ -13,7 +13,7 @@ endif
 
 let s:incIndent =
       \ '^\s*\%(loop\|alt\|opt\|group\|critical\|else\|legend\|box\|if\|while\)\>\|' .
-      \ '^\s*\%([hr]\?note\|ref\)\>[^:]*$\|' .
+      \ '^\s*\%([hr]\?note\|ref\)\>\%(\%(\<as\>\)\@![^:]\)*$\|' .
       \ '^\s*title\s*$\|' .
       \ '^\s*skinparam\>.*{\s*$\|' .
       \ '^\s*\%(state\|class\|partition\|rectangle\)\>.*{'


### PR DESCRIPTION
The pattern I noticed was added.


I use \%(\).

From help
> 	Just like \(\), but without counting it as a sub-expression.  This
>	allows using more groups and it's a little bit faster.
