### PR TITLE
Remove inaccurate Last Change

### DIFF
--- a/ftdetect/plantuml.vim
+++ b/ftdetect/plantuml.vim
@@ -1,7 +1,6 @@
 " Vim ftdetect file
 " Language:     PlantUML
 " Maintainer:   Aaron C. Meadows < language name at shadowguarddev dot com>
-" Last Change:  19-Jun-2012
 " Version:      0.1
 
 if did_filetype()

--- a/ftplugin/plantuml.vim
+++ b/ftplugin/plantuml.vim
@@ -1,7 +1,6 @@
 " Vim plugin file
 " Language:     PlantUML
 " Maintainer:   Aaron C. Meadows < language name at shadowguarddev dot com>
-" Last Change:  19-Jun-2012
 " Version:      0.1
 
 if exists("b:loaded_plantuml_plugin")

--- a/syntax/plantuml.vim
+++ b/syntax/plantuml.vim
@@ -1,7 +1,6 @@
 " Vim syntax file
 " Language:     PlantUML
 " Maintainer:   Anders Thøgersen <first name at bladre dot dk>
-" Last Change:  03-Apr-2011
 " Version:      0.2
 " TODO:         There are some bugs, add << >>
 "


### PR DESCRIPTION
"Last Change: " can not keep up with the update, so do not erase it?
I think that it is better to delete "Version:" as well.
How about transferring " syntax/plantuml.vim  TODO:" to Github Issues?