### PR TITLE
plantumlClass available only for class diagrams

### DIFF
--- a/syntax/plantuml.vim
+++ b/syntax/plantuml.vim
@@ -38,7 +38,7 @@ syntax region plantumlLabel start=/\[/ms=s+1 end=/\]/me=s-1 contained contains=p
 syntax match plantumlText /\%([0-9A-Za-zÀ-ÿ]\|\s\|[\.,;_-]\)\+/ contained
 
 " Class
-syntax region plantumlClass start=/\%(class\s[^{]\+\)\@<=\zs{/ end=/\s*}/ contains=plantumlClassArrows,
+syntax region plantumlClass start=/\%(class\s[^{]\+\)\@<=\zs{/ end=/^\s*}/ contains=plantumlClassArrows,
 \                                                                                  plantumlClassKeyword,
 \                                                                                  @plantumlClassOp,
 \                                                                                  plantumlClassSeparator,

--- a/syntax/plantuml.vim
+++ b/syntax/plantuml.vim
@@ -38,11 +38,11 @@ syntax region plantumlLabel start=/\[/ms=s+1 end=/\]/me=s-1 contained contains=p
 syntax match plantumlText /\%([0-9A-Za-zÀ-ÿ]\|\s\|[\.,;_-]\)\+/ contained
 
 " Class
-syntax region plantumlClass start=/{/ end=/\s*}/ contains=plantumlClassArrows,
-\                                                         plantumlClassKeyword,
-\                                                         @plantumlClassOp,
-\                                                         plantumlClassSeparator,
-\                                                         plantumlComment
+syntax region plantumlClass start=/\%(class\)\@<=\s[^{]\+{/ end=/\s*}/ contains=plantumlClassArrows,
+\                                                                               plantumlClassKeyword,
+\                                                                               @plantumlClassOp,
+\                                                                               plantumlClassSeparator,
+\                                                                               plantumlComment
 
 syntax match plantumlClassPublic      /+\w\+/ contained
 syntax match plantumlClassPrivate     /-\w\+/ contained

--- a/syntax/plantuml.vim
+++ b/syntax/plantuml.vim
@@ -38,11 +38,11 @@ syntax region plantumlLabel start=/\[/ms=s+1 end=/\]/me=s-1 contained contains=p
 syntax match plantumlText /\%([0-9A-Za-zÀ-ÿ]\|\s\|[\.,;_-]\)\+/ contained
 
 " Class
-syntax region plantumlClass start=/\%(class\)\@<=\s[^{]\+{/ end=/\s*}/ contains=plantumlClassArrows,
-\                                                                               plantumlClassKeyword,
-\                                                                               @plantumlClassOp,
-\                                                                               plantumlClassSeparator,
-\                                                                               plantumlComment
+syntax region plantumlClass start=/\%(class\s[^{]\+\)\@<=\zs{/ end=/\s*}/ contains=plantumlClassArrows,
+\                                                                                  plantumlClassKeyword,
+\                                                                                  @plantumlClassOp,
+\                                                                                  plantumlClassSeparator,
+\                                                                                  plantumlComment
 
 syntax match plantumlClassPublic      /+\w\+/ contained
 syntax match plantumlClassPrivate     /-\w\+/ contained


### PR DESCRIPTION
Since {} is also used other than class diagram, I have made plantumlClass available only for class diagram.

before:
![2-12-1-before](https://cloud.githubusercontent.com/assets/99910/25778478/76a1f2e0-3339-11e7-8e63-798b0dd1e460.png)

after:
![2-12-1-after](https://cloud.githubusercontent.com/assets/99910/25778477/76a14836-3339-11e7-9fcf-b213bfa67a2e.png)
