### PR TITLE
Fix vint warning

### DIFF
--- a/ftplugin/plantuml.vim
+++ b/ftplugin/plantuml.vim
@@ -3,18 +3,18 @@
 " Maintainer:   Aaron C. Meadows < language name at shadowguarddev dot com>
 " Version:      0.1
 
-if exists("b:loaded_plantuml_plugin")
+if exists('b:loaded_plantuml_plugin')
   finish
 endif
 let b:loaded_plantuml_plugin = 1
 let s:cpo_save = &cpo
 set cpo&vim
 
-if !exists("g:plantuml_executable_script")
-  let g:plantuml_executable_script="plantuml"
+if !exists('g:plantuml_executable_script')
+  let g:plantuml_executable_script='plantuml'
 endif
 
-if exists("loaded_matchit")
+if exists('loaded_matchit')
   let b:match_ignorecase = 0
   let b:match_words =
         \ '\(\<ref\>\|\<box\>\|\<opt\>\|\<alt\>\|\<group\>\|\<loop\>\|\<note\>\|\<legend\>\):\<else\>:\<end\>' .
@@ -25,7 +25,7 @@ if exists("loaded_matchit")
         \ ',\<\while\>:\<endwhile\>'
 endif
 
-let &l:makeprg=g:plantuml_executable_script . " " .  fnameescape(expand("%"))
+let &l:makeprg=g:plantuml_executable_script . ' ' .  fnameescape(expand('%'))
 
 setlocal comments=s1:/',mb:',ex:'/,:' commentstring=/'%s'/ formatoptions-=t formatoptions+=croql
 

--- a/indent/plantuml.vim
+++ b/indent/plantuml.vim
@@ -1,4 +1,4 @@
-if exists("b:did_indent")
+if exists('b:did_indent')
   finish
 endif
 let b:did_indent = 1
@@ -7,7 +7,7 @@ setlocal indentexpr=GetPlantUMLIndent()
 setlocal indentkeys=o,O,<CR>,<:>,!^F,0end,0else,}
 
 " only define the indent code once
-if exists("*GetPlantUMLIndent")
+if exists('*GetPlantUMLIndent')
   finish
 endif
 

--- a/syntax/plantuml.vim
+++ b/syntax/plantuml.vim
@@ -1,20 +1,21 @@
+scriptencoding utf-8
 " Vim syntax file
 " Language:     PlantUML
 " Maintainer:   Anders Thøgersen <first name at bladre dot dk>
 " Version:      0.2
 "
-if exists("b:current_syntax")
+if exists('b:current_syntax')
   finish
 endif
 
-if version < 600
+if v:version < 600
   syntax clear
 endif
 
 let s:cpo_orig=&cpo
 set cpo&vim
 
-let b:current_syntax = "plantuml"
+let b:current_syntax = 'plantuml'
 
 syntax sync minlines=100
 


### PR DESCRIPTION
Fixed the following warnings presented by [vint](https://github.com/Kuniwak/vint).

- Prefer single quoted strings (see Google VimScript Style Guide (Strings))
- Use scriptencoding when multibyte char exists (see :help :scriptencoding)
- Make the scope explicit like `v:version` (or possibly be unexpected builtin?) (see :help local-variable)
