### PR TITLE
Add Space in Sequence Diagram

### DIFF
--- a/syntax/plantuml.vim
+++ b/syntax/plantuml.vim
@@ -74,6 +74,8 @@ syntax match plantumlActivitySynch /===[^=]\+===/
 
 " Sequence diagram
 syntax match plantumlSequenceDivider /^\s*==[^=]\+==\s*$/
+syntax match plantumlSequenceSpace /^\s*|||\+\s*$/
+syntax match plantumlSequenceSpace /^\s*||\d\+||\+\s*$/
 
 " Usecase diagram
 syntax match plantumlUsecaseActor /:.\{-1,}:/ contains=plantumlSpecialString
@@ -169,6 +171,7 @@ highlight default link plantumlClassProtected Statement
 highlight default link plantumlClassPackPrivate Function
 highlight default link plantumlClassSeparator Comment
 highlight default link plantumlSequenceDivider Comment
+highlight default link plantumlSequenceSpace Comment
 highlight default link plantumlSpecialString Special
 highlight default link plantumlString String
 highlight default link plantumlComment Comment


### PR DESCRIPTION
Example:

```
@startuml
Alice -> Bob: message 1
Bob --> Alice: ok
|||
Alice -> Bob: message 2
Bob --> Alice: ok
||45||
Alice -> Bob: message 3
Bob --> Alice: ok
@enduml
```

![1-17-1_space_vim](https://cloud.githubusercontent.com/assets/99910/26031663/db10e0b0-38b6-11e7-87ed-bcfb2b09e056.png)

![1-17-1_space](https://cloud.githubusercontent.com/assets/99910/25690166/762d16c2-30c9-11e7-9894-770ebfc1a1c4.png)
