### PR TITLE
Fix activity label syntax

### DIFF
--- a/syntax/plantuml.vim
+++ b/syntax/plantuml.vim
@@ -99,7 +99,7 @@ syntax match plantumlStereotype /<<.\{-1,}>>/ contains=plantumlSpecialString
 " Activity diagram
 syntax match plantumlActivityThing /([^)]*)/
 syntax match plantumlActivitySynch /===[^=]\+===/
-syntax region plantumlActivityLabel start=/:/ end=/[;|<>/\]}]$/ contains=plantumlSpecialString
+syntax match plantumlActivityLabel /\%(^\%(#\S\+\)\?\)\@<=:\_[^;|<>/\]}]\+[;|<>/\]}]$/ contains=plantumlSpecialString
 
 " Sequence diagram
 syntax match plantumlSequenceDivider /^\s*==[^=]\+==\s*$/


### PR DESCRIPTION
Fix this wrong highlight:

![1-10-1_vim_wrong](https://cloud.githubusercontent.com/assets/99910/26281615/9bdaf5bc-3e37-11e7-96e3-a322fe7454ab.png)

```
@startuml
Alice->Bob : hello
note left: this is a first note
Bob->Alice : ok
note right: this is another note
Bob->Bob : I am thinking
note left
a note
can also be defined
on several lines
end note
@enduml
```
