### PR TITLE
Use built-in % filename substitution in makeprg

### DIFF
--- a/ftplugin/plantuml.vim
+++ b/ftplugin/plantuml.vim
@@ -20,7 +20,7 @@ if exists('loaded_matchit')
         \ ',\<\while\>:\<endwhile\>'
 endif
 
-let &l:makeprg=g:plantuml_executable_script . ' ' .  fnameescape(expand('%'))
+let &l:makeprg=g:plantuml_executable_script . ' %'
 
 setlocal comments=s1:/',mb:',ex:'/,:' commentstring=/'%s'/ formatoptions-=t formatoptions+=croql
 


### PR DESCRIPTION
Currently, plantuml-syntax interpolates the current filename directly into the `makeprg` setting. If the filename changes (_e.g.,_ via `:sav new_filename.uml`), the `makeprg` no longer matches the new file.

Using a literal `%` symbol instead prevents this problem.