### PR TITLE
Add 'split' for SDL diagram

### DIFF
--- a/syntax/plantuml.vim
+++ b/syntax/plantuml.vim
@@ -31,7 +31,7 @@ syntax keyword plantumlKeyword activate again also alt as autonumber bottom box 
 syntax keyword plantumlKeyword critical deactivate destroy down else elseif end endif endwhile footbox footer
 syntax keyword plantumlKeyword fork group header hide hnote if is kill left legend link loop namespace newpage
 syntax keyword plantumlKeyword note of on opt over package page par partition ref repeat return right rnote
-syntax keyword plantumlKeyword rotate show skin skinparam start stop title top up while
+syntax keyword plantumlKeyword rotate show skin skinparam split start stop title top up while
 " Not in 'java - jar plantuml.jar - language' output
 syntax keyword plantumlKeyword then detach sprite
 


### PR DESCRIPTION
`split ... end` block is a syntax of SDL diagram.

e.g.

```
split
 :nak(i)<
 :ack(o)>
split again
 :ack(i)<
 :next(o)
 on several lines|
 :i := i + 1]
 :ack(o)>
split again
 :err(i)<
 :nak(o)>
split again
 :foo/
split again
 :i > 5}
stop
end split
```

I added `split` as keyword to highlight it.

ref: http://en.plantuml.com/activity-diagram-beta