### PR TITLE
increase indent level on 'fork' and 'split' blocks

### DIFF
--- a/indent/plantuml.vim
+++ b/indent/plantuml.vim
@@ -12,7 +12,7 @@ if exists('*GetPlantUMLIndent')
 endif
 
 let s:incIndent =
-      \ '^\s*\%(loop\|alt\|opt\|group\|critical\|else\|legend\|box\|if\|while\)\>\|' .
+      \ '^\s*\%(loop\|alt\|opt\|group\|critical\|else\|legend\|box\|if\|while\|fork\|split\)\>\|' .
       \ '^\s*ref\>[^:]*$\|' .
       \ '^\s*[hr]\?note\>\%(\%("[^"]*" \<as\>\)\@![^:]\)*$\|' .
       \ '^\s*title\s*$\|' .


### PR DESCRIPTION
`fork` and `split` construct blocks and they should increase an indent level. This PR make `fork` and `split` increase indentation.