### PR TITLE
Fix 'plantuml' filetype detection

### DIFF
--- a/ftdetect/plantuml.vim
+++ b/ftdetect/plantuml.vim
@@ -1,6 +1,2 @@
-if did_filetype()
-  finish
-endif
-
-autocmd BufRead,BufNewFile * :if getline(1) =~ '^.*startuml.*$'| setfiletype plantuml | set filetype=plantuml | endif
-autocmd BufRead,BufNewFile *.pu,*.uml,*.plantuml,*.puml setfiletype plantuml | set filetype=plantuml
+autocmd BufRead,BufNewFile * if !did_filetype() && getline(1) =~# '@startuml\>'| setfiletype plantuml | endif
+autocmd BufRead,BufNewFile *.pu,*.uml,*.plantuml,*.puml set filetype=plantuml


### PR DESCRIPTION
For first line, `did_filetype()` should be referred only when the filetype is detected from its file content. For second line, `setfiletype plantuml` is duplicate since `set filetype=plantuml` sets filetype.