### PR TITLE
Skip setting makeprg if makefile exists

### DIFF
--- a/ftplugin/plantuml.vim
+++ b/ftplugin/plantuml.vim
@@ -20,7 +20,9 @@ if exists('loaded_matchit')
         \ ',\<\while\>:\<endwhile\>'
 endif
 
-let &l:makeprg=g:plantuml_executable_script . ' ' .  fnameescape(expand('%'))
+if !(filereadable("Makefile") || filereadable("makefile") || filereadable("GNUmakefile"))
+  let &l:makeprg=g:plantuml_executable_script . ' ' .  fnameescape(expand('%'))
+endif
 
 setlocal comments=s1:/',mb:',ex:'/,:' commentstring=/'%s'/ formatoptions-=t formatoptions+=croql
 


### PR DESCRIPTION
Sometimes I want to use `:make` to use Makefile instead of a single plantuml command. So I made this to avoid setting `makeprg` if makefile exists in the current directory.

Thank you.