### PR TITLE
Add flag to prevent makeprg from being set

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,4 @@ java -jar $HOME/lib/java/plantuml.jar -tsvg $@
 ````
 
 You can change the name of this file by setting `g:plantuml_executable_script`
+and disable this feature by setting `g:plantuml_set_makeprg` to `0`.

--- a/ftplugin/plantuml.vim
+++ b/ftplugin/plantuml.vim
@@ -27,7 +27,9 @@ if exists('loaded_matchit')
         \ ',@startuml:@enduml'
 endif
 
-let &l:makeprg=g:plantuml_executable_script . ' %'
+if get(g:, 'plantuml_set_makeprg', 1)
+  let &l:makeprg=g:plantuml_executable_script . ' %'
+endif
 
 setlocal comments=s1:/',mb:',ex:'/,:' commentstring=/'%s'/ formatoptions-=t formatoptions+=croql
 


### PR DESCRIPTION
This adds a flag `g:plantuml_set_makeprg` to prevent makeprg from being set instead of #65.
I can change the description I wrote in the README if you have any other style you like.