### PR TITLE
Add keywords for gantt charts

### DIFF
--- a/syntax/plantuml.vim
+++ b/syntax/plantuml.vim
@@ -32,7 +32,7 @@ syntax keyword plantumlClassKeyword class interface
 " Exclude 'top to bottom direction'
 syntax keyword plantumlKeyword accross activate again allow_mixing allowmixing also alt as autonumber bottom
 syntax keyword plantumlKeyword box break caption center create critical deactivate destroy down else elseif end
-syntax keyword plantumlKeyword endif endwhile footbox footer fork group header hide hnote if is kill left in at are to the
+syntax keyword plantumlKeyword endif endwhile footbox footer fork group header hide hnote if is kill left in at are to the and
 syntax keyword plantumlKeyword legend link loop mainframe namespace newpage note of on opt order over package
 syntax keyword plantumlKeyword page par partition ref repeat return right rnote rotate show skin skinparam
 syntax keyword plantumlKeyword start stop title top up while
@@ -40,7 +40,7 @@ syntax keyword plantumlKeyword start stop title top up while
 syntax keyword plantumlKeyword then detach split sprite
 " gantt
 syntax keyword plantumlTypeKeyword project monday tuesday wednesday thursday friday saturday sunday
-syntax keyword plantumlKeyword starts closed day after colored lasts end
+syntax keyword plantumlKeyword starts ends start end closed day after colored lasts happens
 
 
 syntax keyword plantumlCommentTODO XXX TODO FIXME NOTE contained

--- a/syntax/plantuml.vim
+++ b/syntax/plantuml.vim
@@ -18,7 +18,7 @@ let b:current_syntax = 'plantuml'
 
 syntax sync minlines=100
 
-syntax match plantumlPreProc /\%(\%(^@start\|^@end\)\%(dot\|mindmap\|uml\|salt\|wbs\)\)\|!\%(define\|definelong\|else\|enddefinelong\|endif\|exit\|if\|ifdef\|ifndef\|include\|pragma\|undef\)\s*.*/ contains=plantumlDir
+syntax match plantumlPreProc /\%(\%(^@start\|^@end\)\%(dot\|mindmap\|uml\|salt\|wbs\|gantt\)\)\|!\%(define\|definelong\|else\|enddefinelong\|endif\|exit\|if\|ifdef\|ifndef\|include\|pragma\|undef\|gantt\)\s*.*/ contains=plantumlDir
 syntax region plantumlDir start=/\s\+/ms=s+1 end=/$/ contained
 
 " type
@@ -32,12 +32,16 @@ syntax keyword plantumlClassKeyword class interface
 " Exclude 'top to bottom direction'
 syntax keyword plantumlKeyword accross activate again allow_mixing allowmixing also alt as autonumber bottom
 syntax keyword plantumlKeyword box break caption center create critical deactivate destroy down else elseif end
-syntax keyword plantumlKeyword endif endwhile footbox footer fork group header hide hnote if is kill left
+syntax keyword plantumlKeyword endif endwhile footbox footer fork group header hide hnote if is kill left in at are to the
 syntax keyword plantumlKeyword legend link loop mainframe namespace newpage note of on opt order over package
 syntax keyword plantumlKeyword page par partition ref repeat return right rnote rotate show skin skinparam
 syntax keyword plantumlKeyword start stop title top up while
 " Not in 'java - jar plantuml.jar - language' output
 syntax keyword plantumlKeyword then detach split sprite
+" gantt
+syntax keyword plantumlTypeKeyword project monday tuesday wednesday thursday friday saturday sunday
+syntax keyword plantumlKeyword starts closed day after colored lasts end
+
 
 syntax keyword plantumlCommentTODO XXX TODO FIXME NOTE contained
 syntax match plantumlColor /#[0-9A-Fa-f]\{6\}\>/


### PR DESCRIPTION
PlantUML can generate gantt charts.

This PR defines the required keywords.

There is still a problem with : inside a resource definition and with ' when connecting tasks.
In both cases the remaining text on the line will be displayed as a comment.