### PR TITLE
Do not use 'augroup' in ftdetect

### DIFF
--- a/ftdetect/plantuml.vim
+++ b/ftdetect/plantuml.vim
@@ -3,7 +3,7 @@ scriptencoding utf-8
 " Language:     PlantUML
 " Maintainer:   Anders Thøgersen <first name at bladre dot dk>
 " License:      VIM LICENSE
-augroup PlantUML
-  autocmd BufRead,BufNewFile * if !did_filetype() && getline(1) =~# '@startuml\>'| setfiletype plantuml | endif
-  autocmd BufRead,BufNewFile *.pu,*.uml,*.plantuml,*.puml,*.iuml set filetype=plantuml
-augroup END
+
+" Note: should not use augroup in ftdetect (see :help ftdetect)
+autocmd BufRead,BufNewFile * if !did_filetype() && getline(1) =~# '@startuml\>'| setfiletype plantuml | endif
+autocmd BufRead,BufNewFile *.pu,*.uml,*.plantuml,*.puml,*.iuml set filetype=plantuml


### PR DESCRIPTION
There is no `augroup` command in an `ftdetect` file (see `:help ftdetect`). This breaks plugins loaded after the plantuml-syntax plugin. As an example, if the plantuml-syntax plugin is loaded before the [fatih/vim-go](https://github.com/fatih/vim-go) plugin, the filetype detection for [go.mod](https://github.com/fatih/vim-go/blob/b995086646f29de25acbe7df2c08cc196c4641d7/ftdetect/gofiletype.vim#L12-L19) files breaks.