### PR TITLE
Actor syntax highlight conflicts with sequence diagram

### DIFF
--- a/syntax/plantuml.vim
+++ b/syntax/plantuml.vim
@@ -142,8 +142,7 @@ syntax match plantumlSequenceDelay /^\.\{3}$/
 syntax region plantumlText oneline matchgroup=plantumlSequenceDelay start=/^\.\{3}/ end=/\.\{3}$/
 
 " Usecase diagram
-syntax match plantumlUsecaseActor /:.\{-1,}:/ contains=plantumlSpecialString
-
+syntax match plantumlUsecaseActor /^:.\{-1,}:/ contains=plantumlSpecialString
 
 " Mindmap diagram
 let s:mindmapHilightLinks = [

--- a/syntax/plantuml.vim
+++ b/syntax/plantuml.vim
@@ -142,7 +142,8 @@ syntax match plantumlSequenceDelay /^\.\{3}$/
 syntax region plantumlText oneline matchgroup=plantumlSequenceDelay start=/^\.\{3}/ end=/\.\{3}$/
 
 " Usecase diagram
-syntax match plantumlUsecaseActor /^:.\{-1,}:/ contains=plantumlSpecialString
+syntax match plantumlUsecaseActor /^\s*:.\{-1,}:/ contains=plantumlSpecialString
+
 
 " Mindmap diagram
 let s:mindmapHilightLinks = [


### PR DESCRIPTION
If I add a sequence diagram message that contains ":" character, this cause the syntax highlighting to be broken for the rest of that sequence diagram, eg: `mobile_phone -> mobile_phone: send a message containing ":"`

I've never used the use case diagram but based on https://plantuml.com/use-case-diagram, this seems like a reasonable fix.