### PR TITLE
Allow leading space on delay lines

### DIFF
--- a/syntax/plantuml.vim
+++ b/syntax/plantuml.vim
@@ -138,8 +138,8 @@ syntax match plantumlActivityLabel /\%(^\%(#\S\+\)\?\)\@<=:\_[^;|<>/\]}]\+[;|<>/
 syntax match plantumlSequenceDivider /^\s*==[^=]\+==\s*$/
 syntax match plantumlSequenceSpace /^\s*|||\+\s*$/
 syntax match plantumlSequenceSpace /^\s*||\d\+||\+\s*$/
-syntax match plantumlSequenceDelay /^\.\{3}$/
-syntax region plantumlText oneline matchgroup=plantumlSequenceDelay start=/^\.\{3}/ end=/\.\{3}$/
+syntax match plantumlSequenceDelay /^\s*\.\{3}$/
+syntax region plantumlText oneline matchgroup=plantumlSequenceDelay start=/^\s*\.\{3}/ end=/\.\{3}$/
 
 " Usecase diagram
 syntax match plantumlUsecaseActor /:.\{-1,}:/ contains=plantumlSpecialString


### PR DESCRIPTION
This patch causes delays to be syntax highlighted correctly
when there're space characters before the first dots.

I.e. the text in between the triple dots in the example below is
now highlighted as a delay.

```plantuml
group My own label
    Bob -> Alice: Authentication Request
    ... wait a while ...
    Bob <- Alice: Authentication Accepted
end
```