### PR TITLE
Colon labels should have spaces around them

### DIFF
--- a/syntax/plantuml.vim
+++ b/syntax/plantuml.vim
@@ -95,7 +95,7 @@ syntax match plantumlNoteMultiLineStart /\%(^\s*[rh]\?\%(note\|legend\)\)\@<=\s\
 " Class
 syntax region plantumlClass
       \ start=/\%(\%(class\|interface\|object\)\s[^{]\+\)\@<=\zs{/
-      \ end=/^\s*}/ 
+      \ end=/^\s*}/
       \ contains=plantumlClassArrows,
       \          plantumlClassKeyword,
       \          @plantumlClassOp,
@@ -124,7 +124,7 @@ syntax match plantumlTag /<\/\?[bi]>/
 syntax region plantumlTag start=/<\/\?\%(back\|color\|del\|font\|img\|s\|size\|strike\|u\|w\)/ end=/>/
 
 " Labels with a colon
-syntax match plantumlColonLine /\S\@<=\s*\zs:.\+$/ contains=plantumlSpecialString
+syntax match plantumlColonLine /\S\@<=\s*\zs : .\+$/ contains=plantumlSpecialString
 
 " Stereotypes
 syntax match plantumlStereotype /<<[^-.]\+>>/ contains=plantumlSpecialString


### PR DESCRIPTION
We were getting false matches before for ColonLine, mostly for class
diagrams. Check out the following example before and after in your
editor:

```plantuml
@startuml
class Foo {
+ field1
+ field2
}

class Bar {
+ field3
+ field4
}

Foo::field1 --> Bar::field3 : foo
Foo::field2 --> Bar::field4 : bar
@enduml
```

Notice how the fields at the end are highlighted all weird? This PR
fixes that problem.

## Before

![image](https://user-images.githubusercontent.com/3723671/108964073-dc824f00-762f-11eb-8e8d-d80b560726a8.png)

## After

![image](https://user-images.githubusercontent.com/3723671/108964018-caa0ac00-762f-11eb-904a-233b09ef515a.png)
