### PR TITLE
Remove scriptencoding

### DIFF
--- a/ftdetect/plantuml.vim
+++ b/ftdetect/plantuml.vim
@@ -1,4 +1,3 @@
-scriptencoding utf-8
 " Vim filetype detection file
 " Language:     PlantUML
 " License:      VIM LICENSE

--- a/ftplugin/plantuml.vim
+++ b/ftplugin/plantuml.vim
@@ -1,4 +1,3 @@
-scriptencoding utf-8
 " Vim filetype plugin file
 " Language:     PlantUML
 " License:      VIM LICENSE

--- a/indent/plantuml.vim
+++ b/indent/plantuml.vim
@@ -1,4 +1,3 @@
-scriptencoding utf-8
 " Vim indent file
 " Language:     PlantUML
 " License:      VIM LICENSE

--- a/syntax/plantuml.vim
+++ b/syntax/plantuml.vim
@@ -1,4 +1,3 @@
-scriptencoding utf-8
 " Vim syntax file
 " Language:     PlantUML
 " License:      VIM LICENSE


### PR DESCRIPTION
No longer needed due to the removal of the maintainer notation.