### PR TITLE
Provide an error format for makeprg

### DIFF
--- a/ftplugin/plantuml.vim
+++ b/ftplugin/plantuml.vim
@@ -29,6 +29,7 @@ endif
 
 if get(g:, 'plantuml_set_makeprg', 1)
   let &l:makeprg=g:plantuml_executable_script . ' %'
+  let &l:errorformat='Error\ line %l in file: %f,%Z%m'
 endif
 
 setlocal comments=s1:/',mb:',ex:'/,:' commentstring=/'%s'/ formatoptions-=t formatoptions+=croql


### PR DESCRIPTION
Add an error format specification for PlantUML. Old versions of PlantUML always
had an offset in the error line number, but since this is fixed now, Vim should
pick this up for :make.
